### PR TITLE
feat: transact v41 catchup

### DIFF
--- a/api/oas_generator/rust_oas_generator/templates/models/block/signed_txn_in_block.rs.j2
+++ b/api/oas_generator/rust_oas_generator/templates/models/block/signed_txn_in_block.rs.j2
@@ -27,14 +27,6 @@ pub struct SignedTxnInBlock {
     /// SignedTransaction fields (flattened from algokit_transact)
     #[serde(flatten)]
     pub signed_transaction: AlgokitSignedTransaction,
-    /// [lsig] Logic signature (program signature).
-    #[serde(
-        with = "crate::msgpack_value_bytes",
-        default,
-        rename = "lsig",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub logic_signature: Option<Vec<u8>>,
     /// [ca] Rewards applied to close-remainder-to account.
     #[serde(rename = "ca", skip_serializing_if = "Option::is_none")]
     pub closing_amount: Option<u64>,
@@ -95,8 +87,8 @@ impl Default for SignedTxnInBlock {
                 signature: None,
                 auth_address: None,
                 multisignature: None,
+                logic_signature: None,
             },
-            logic_signature: None,
             closing_amount: None,
             asset_closing_amount: None,
             sender_rewards: None,

--- a/api/oas_generator/rust_oas_generator/templates/models/model.rs.j2
+++ b/api/oas_generator/rust_oas_generator/templates/models/model.rs.j2
@@ -181,6 +181,7 @@ impl Default for {{ schema.rust_struct_name }} {
                 signature: None,
                 auth_address: None,
                 multisignature: None,
+                logic_signature: None,
             }{% endif %}{% else %}None{% endif %},
             {% elif property.required %}
             {{ property.rust_field_name }}: {% if property.rust_type == "String" %}"".to_string(){% elif property.rust_type.startswith('Vec<') %}Vec::new(){% elif property.rust_type.startswith('i') or property.rust_type.startswith('u') %}0{% elif property.rust_type == "bool" %}false{% elif property.rust_type == "serde_json::Value" %}serde_json::Value::Null{% else %}Default::default(){% endif %},

--- a/crates/algod_client/src/models/pending_transaction_response.rs
+++ b/crates/algod_client/src/models/pending_transaction_response.rs
@@ -116,6 +116,7 @@ impl Default for PendingTransactionResponse {
                 signature: None,
                 auth_address: None,
                 multisignature: None,
+                logic_signature: None,
             },
         }
     }

--- a/crates/algod_client/src/models/signed_txn_in_block.rs
+++ b/crates/algod_client/src/models/signed_txn_in_block.rs
@@ -27,14 +27,6 @@ pub struct SignedTxnInBlock {
     /// SignedTransaction fields (flattened from algokit_transact)
     #[serde(flatten)]
     pub signed_transaction: AlgokitSignedTransaction,
-    /// [lsig] Logic signature (program signature).
-    #[serde(
-        with = "crate::msgpack_value_bytes",
-        default,
-        rename = "lsig",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub logic_signature: Option<Vec<u8>>,
     /// [ca] Rewards applied to close-remainder-to account.
     #[serde(rename = "ca", skip_serializing_if = "Option::is_none")]
     pub closing_amount: Option<u64>,
@@ -95,8 +87,8 @@ impl Default for SignedTxnInBlock {
                 signature: None,
                 auth_address: None,
                 multisignature: None,
+                logic_signature: None,
             },
-            logic_signature: None,
             closing_amount: None,
             asset_closing_amount: None,
             sender_rewards: None,

--- a/crates/algod_client/tests/models.rs
+++ b/crates/algod_client/tests/models.rs
@@ -84,3 +84,22 @@ fn box_reference_roundtrip() {
     assert_eq!(parsed, value);
     assert_eq!(parsed.name, vec![1, 2, 3, 4]);
 }
+
+/// A logic signature inside a block-embedded transaction must reach the flattened
+/// `algokit_transact::SignedTransaction`, not a competing field on the outer struct.
+#[test]
+fn signed_txn_in_block_carries_a_logic_signature() {
+    use algod_client::models::SignedTxnInBlock;
+
+    let mut stxn = SignedTxnInBlock::new();
+    stxn.signed_transaction.logic_signature =
+        Some(algokit_transact::LogicSignature::new(vec![1, 32, 1, 1, 34]));
+
+    let encoded = rmp_serde::to_vec_named(&stxn).unwrap();
+    let decoded: SignedTxnInBlock = rmp_serde::from_slice(&encoded).unwrap();
+
+    assert_eq!(
+        decoded.signed_transaction.logic_signature,
+        stxn.signed_transaction.logic_signature
+    );
+}

--- a/crates/algokit_composer/src/signer.rs
+++ b/crates/algokit_composer/src/signer.rs
@@ -60,6 +60,7 @@ fn sign_transaction(
         signature: Some(signature),
         auth_address: None,
         multisignature: None,
+        logic_signature: None,
     })
 }
 

--- a/crates/algokit_composer/src/simulate.rs
+++ b/crates/algokit_composer/src/simulate.rs
@@ -481,7 +481,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_signature_envelope_differs_from_zero_signature() {
+    fn empty_signature_envelope_matches_a_zero_signature() {
         let txn = payment();
         let empty = empty_signature_envelope(txn.clone());
         let zeroed = SignedTransaction {
@@ -491,14 +491,11 @@ mod tests {
             multisignature: None,
         };
 
+        // An all-zero signature is omitted, so both produce the same envelope.
+        assert_eq!(envelope_keys(&zeroed), vec!["txn".to_string()]);
         assert_eq!(
-            envelope_keys(&zeroed),
-            vec!["txn".to_string(), "sig".to_string()]
-        );
-        assert_ne!(
             rmp_serde::to_vec_named(&empty).unwrap(),
             rmp_serde::to_vec_named(&zeroed).unwrap(),
-            "an all-zero signature is not the same wire shape as an absent one"
         );
     }
 

--- a/crates/algokit_composer/src/simulate.rs
+++ b/crates/algokit_composer/src/simulate.rs
@@ -125,6 +125,7 @@ pub fn empty_signature_envelope(transaction: Transaction) -> SignedTransaction {
         signature: None,
         auth_address: None,
         multisignature: None,
+        logic_signature: None,
     }
 }
 
@@ -489,6 +490,7 @@ mod tests {
             signature: Some([0u8; 64]),
             auth_address: None,
             multisignature: None,
+            logic_signature: None,
         };
 
         // An all-zero signature is omitted, so both produce the same envelope.
@@ -522,6 +524,7 @@ mod tests {
             signature: Some([7u8; 64]),
             auth_address: None,
             multisignature: None,
+            logic_signature: None,
         };
 
         let request =
@@ -542,6 +545,7 @@ mod tests {
             signature: Some([7u8; 64]),
             auth_address: None,
             multisignature: None,
+            logic_signature: None,
         };
 
         let request = build_simulate_request(vec![signed], &SimulateOptions::default()).unwrap();
@@ -826,6 +830,7 @@ mod tests {
             signature: Some([9u8; 64]),
             auth_address: None,
             multisignature: None,
+            logic_signature: None,
         };
         let client = StubHttpClient {
             response: response_for(&[txn]),

--- a/crates/algokit_transact/src/constants.rs
+++ b/crates/algokit_transact/src/constants.rs
@@ -12,6 +12,11 @@ pub const MULTISIG_DOMAIN_SEPARATOR: &str = "MultisigAddr";
 pub const EMPTY_SIGNATURE: [u8; ALGORAND_SIGNATURE_BYTE_LENGTH] =
     [0; ALGORAND_SIGNATURE_BYTE_LENGTH];
 
+// LogicSig domain separators and program size limit
+pub const PROGRAM_DOMAIN_SEPARATOR: &str = "Program";
+pub const MULTISIG_PROGRAM_DOMAIN_SEPARATOR: &str = "MsigProgram";
+pub const MAX_LOGIC_SIG_SIZE: usize = 16_000; // In bytes
+
 // Application program size constraints
 pub const MAX_EXTRA_PROGRAM_PAGES: u32 = 3;
 pub const PROGRAM_PAGE_SIZE: usize = 2048; // In bytes

--- a/crates/algokit_transact/src/constants.rs
+++ b/crates/algokit_transact/src/constants.rs
@@ -29,6 +29,7 @@ pub const MAX_ACCOUNT_REFERENCES: usize = 4;
 pub const MAX_APP_REFERENCES: usize = 8;
 pub const MAX_ASSET_REFERENCES: usize = 8;
 pub const MAX_BOX_REFERENCES: usize = 8;
+pub const MAX_ACCESS_REFERENCES: usize = 16;
 
 // Application state schema limits
 pub const MAX_GLOBAL_STATE_KEYS: u32 = 64;

--- a/crates/algokit_transact/src/constants.rs
+++ b/crates/algokit_transact/src/constants.rs
@@ -12,10 +12,9 @@ pub const MULTISIG_DOMAIN_SEPARATOR: &str = "MultisigAddr";
 pub const EMPTY_SIGNATURE: [u8; ALGORAND_SIGNATURE_BYTE_LENGTH] =
     [0; ALGORAND_SIGNATURE_BYTE_LENGTH];
 
-// LogicSig domain separators and program size limit
+// LogicSig domain separators
 pub const PROGRAM_DOMAIN_SEPARATOR: &str = "Program";
 pub const MULTISIG_PROGRAM_DOMAIN_SEPARATOR: &str = "MsigProgram";
-pub const MAX_LOGIC_SIG_SIZE: usize = 16_000; // In bytes
 
 // Application program size constraints
 pub const MAX_EXTRA_PROGRAM_PAGES: u32 = 3;

--- a/crates/algokit_transact/src/lib.rs
+++ b/crates/algokit_transact/src/lib.rs
@@ -20,12 +20,13 @@ pub use transactions::{
     AssetConfigTransactionFields, AssetFreezeTransactionBuilder, AssetFreezeTransactionFields,
     AssetTransferTransactionBuilder, AssetTransferTransactionFields, BoxReference,
     FalconSignatureStruct, FalconVerifier, FeeParams, HashFactory, HeartbeatProof,
-    HeartbeatProofBuilder, HeartbeatTransactionBuilder, HeartbeatTransactionFields,
-    KeyRegistrationTransactionBuilder, KeyRegistrationTransactionFields, MerkleArrayProof,
-    MerkleSignatureVerifier, OnApplicationComplete, Participant, PaymentTransactionBuilder,
-    PaymentTransactionFields, Reveal, SignedTransaction, SigslotCommit, StateProof,
-    StateProofMessage, StateProofTransactionBuilder, StateProofTransactionFields, StateSchema,
-    Transaction, TransactionHeader, TransactionHeaderBuilder,
+    HeartbeatProofBuilder, HeartbeatTransactionBuilder, HeartbeatTransactionFields, HoldingRef,
+    KeyRegistrationTransactionBuilder, KeyRegistrationTransactionFields, LocalsRef,
+    MerkleArrayProof, MerkleSignatureVerifier, OnApplicationComplete, Participant,
+    PaymentTransactionBuilder, PaymentTransactionFields, ResourceRef, Reveal, SignedTransaction,
+    SigslotCommit, StateProof, StateProofMessage, StateProofTransactionBuilder,
+    StateProofTransactionFields, StateSchema, Transaction, TransactionHeader,
+    TransactionHeaderBuilder,
 };
 
 #[cfg(feature = "test_utils")]

--- a/crates/algokit_transact/src/lib.rs
+++ b/crates/algokit_transact/src/lib.rs
@@ -1,6 +1,7 @@
 mod address;
 pub mod constants;
 mod error;
+pub mod logic_sig;
 pub mod multisig;
 pub mod signer;
 mod traits;
@@ -11,6 +12,7 @@ mod utils;
 pub use address::Address;
 pub use constants::*;
 pub use error::AlgoKitTransactError;
+pub use logic_sig::LogicSignature;
 pub use multisig::*;
 pub use traits::{AlgorandMsgpack, EstimateTransactionSize, TransactionId, Transactions, Validate};
 pub use transactions::{

--- a/crates/algokit_transact/src/logic_sig.rs
+++ b/crates/algokit_transact/src/logic_sig.rs
@@ -1,0 +1,252 @@
+use serde::{Deserialize, Serialize};
+use serde_with::{Bytes, serde_as};
+
+use crate::constants::{
+    ALGORAND_SIGNATURE_BYTE_LENGTH, MAX_LOGIC_SIG_SIZE, MULTISIG_PROGRAM_DOMAIN_SEPARATOR,
+    PROGRAM_DOMAIN_SEPARATOR,
+};
+use crate::traits::Validate;
+use crate::utils::{hash, is_empty_signature_opt, is_empty_vec_opt};
+use crate::{Address, MultisigSignature};
+
+/// A logic signature, authorizing a transaction with a program rather than a key.
+///
+/// The program can authorize on its own behalf, in which case the transaction sender is
+/// the program's escrow address, or it can be delegated by an account that signs the
+/// program. Exactly one of `signature`, `multisignature` or `logic_multisignature` is
+/// present for a delegated logic signature; all three are absent for an escrow.
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+pub struct LogicSignature {
+    /// The compiled program bytes.
+    #[serde(rename = "l")]
+    #[serde_as(as = "Bytes")]
+    pub logic: Vec<u8>,
+
+    /// Signature of an account delegating to this program. All-zero encodes as absent.
+    #[serde(rename = "sig")]
+    #[serde(skip_serializing_if = "is_empty_signature_opt")]
+    #[serde(default)]
+    #[serde_as(as = "Option<Bytes>")]
+    pub signature: Option<[u8; ALGORAND_SIGNATURE_BYTE_LENGTH]>,
+
+    /// Legacy multisig delegation, rejected since consensus v41. Decoded, never produced.
+    #[serde(rename = "msig")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub multisignature: Option<MultisigSignature>,
+
+    /// Multisig delegation, binding the signature to the delegating account.
+    #[serde(rename = "lmsig")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub logic_multisignature: Option<MultisigSignature>,
+
+    /// Arguments made available to the program. Individual arguments may be empty.
+    #[serde(rename = "arg")]
+    #[serde(skip_serializing_if = "is_empty_vec_opt")]
+    #[serde(default)]
+    #[serde_as(as = "Option<Vec<Bytes>>")]
+    pub args: Option<Vec<Vec<u8>>>,
+}
+
+impl LogicSignature {
+    /// Creates a logic signature for a program authorizing on its own behalf.
+    pub fn new(logic: Vec<u8>) -> Self {
+        Self {
+            logic,
+            ..Default::default()
+        }
+    }
+
+    /// The escrow address this program authorizes as when not delegated.
+    pub fn address(&self) -> Address {
+        Address(hash(&program_preimage(&self.logic)))
+    }
+
+    /// The bytes an account signs to delegate this program to itself.
+    pub fn bytes_to_sign(&self) -> Vec<u8> {
+        program_preimage(&self.logic)
+    }
+
+    /// The bytes a multisig participant signs to delegate this program.
+    ///
+    /// Bound to the multisig account address, so a subsignature cannot be replayed as a
+    /// single-key delegation by the member who produced it.
+    pub fn bytes_to_sign_for_multisig(&self, multisignature: &MultisigSignature) -> Vec<u8> {
+        let account: Address = multisignature.clone().into();
+        let mut buffer = Vec::with_capacity(
+            MULTISIG_PROGRAM_DOMAIN_SEPARATOR.len() + account.as_bytes().len() + self.logic.len(),
+        );
+        buffer.extend_from_slice(MULTISIG_PROGRAM_DOMAIN_SEPARATOR.as_bytes());
+        buffer.extend_from_slice(account.as_bytes());
+        buffer.extend_from_slice(&self.logic);
+        buffer
+    }
+}
+
+fn program_preimage(logic: &[u8]) -> Vec<u8> {
+    let mut buffer = Vec::with_capacity(PROGRAM_DOMAIN_SEPARATOR.len() + logic.len());
+    buffer.extend_from_slice(PROGRAM_DOMAIN_SEPARATOR.as_bytes());
+    buffer.extend_from_slice(logic);
+    buffer
+}
+
+impl Validate for LogicSignature {
+    fn validate(&self) -> Result<(), Vec<String>> {
+        let mut errors = Vec::new();
+
+        if self.logic.is_empty() {
+            errors.push("LogicSig program cannot be empty".to_string());
+        }
+
+        if self.logic.len() > MAX_LOGIC_SIG_SIZE {
+            errors.push(format!(
+                "LogicSig program of {} bytes exceeds the maximum of {} bytes",
+                self.logic.len(),
+                MAX_LOGIC_SIG_SIZE
+            ));
+        }
+
+        let delegations = [
+            self.signature.is_some(),
+            self.multisignature.is_some(),
+            self.logic_multisignature.is_some(),
+        ]
+        .iter()
+        .filter(|present| **present)
+        .count();
+
+        if delegations > 1 {
+            errors.push("LogicSig can carry at most one delegation signature".to_string());
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{AccountMother, PLACEHOLDER_SIGNATURE};
+    use crate::traits::AlgorandMsgpack;
+    use crate::transactions::SignedTransaction;
+    use pretty_assertions::assert_eq;
+
+    /// Program and address from the js-algorand-sdk test suite.
+    const PROGRAM: [u8; 5] = [0x01, 0x20, 0x01, 0x01, 0x22];
+    const ESCROW_ADDRESS: &str = "6Z3C3LDVWGMX23BMSYMANACQOSINPFIRF77H7N3AWJZYV6OH6GWTJKVMXY";
+
+    fn multisig() -> MultisigSignature {
+        MultisigSignature::from_participants(
+            1,
+            2,
+            vec![AccountMother::account(), AccountMother::neil()],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn escrow_address_matches_known_vector() {
+        let lsig = LogicSignature::new(PROGRAM.to_vec());
+        assert_eq!(lsig.address().to_string(), ESCROW_ADDRESS);
+    }
+
+    #[test]
+    fn escrow_address_hashes_the_delegation_preimage() {
+        let lsig = LogicSignature::new(PROGRAM.to_vec());
+        assert_eq!(hash(&lsig.bytes_to_sign()), lsig.address().0);
+    }
+
+    #[test]
+    fn multisig_delegation_binds_the_account_address() {
+        let lsig = LogicSignature::new(PROGRAM.to_vec());
+        let msig = multisig();
+        let account: Address = msig.clone().into();
+
+        let preimage = lsig.bytes_to_sign_for_multisig(&msig);
+
+        assert!(preimage.starts_with(MULTISIG_PROGRAM_DOMAIN_SEPARATOR.as_bytes()));
+        assert_eq!(
+            &preimage[MULTISIG_PROGRAM_DOMAIN_SEPARATOR.len()..][..32],
+            account.as_bytes()
+        );
+        assert!(preimage.ends_with(&PROGRAM));
+        assert_ne!(
+            preimage,
+            lsig.bytes_to_sign(),
+            "multisig delegation must not share a preimage with single-key delegation"
+        );
+    }
+
+    #[test]
+    fn encodes_program_only_when_undelegated() {
+        let encoded = rmp_serde::to_vec_named(&LogicSignature::new(PROGRAM.to_vec())).unwrap();
+        let value: rmpv::Value = rmp_serde::from_slice(&encoded).unwrap();
+
+        let keys: Vec<String> = match value {
+            rmpv::Value::Map(entries) => entries
+                .iter()
+                .filter_map(|(k, _)| k.as_str().map(str::to_string))
+                .collect(),
+            other => panic!("expected a msgpack map, got {other:?}"),
+        };
+
+        assert_eq!(keys, vec!["l".to_string()]);
+    }
+
+    #[test]
+    fn empty_args_are_omitted_but_empty_elements_are_kept() {
+        let mut lsig = LogicSignature::new(PROGRAM.to_vec());
+        lsig.args = Some(vec![]);
+        let encoded = rmp_serde::to_vec_named(&lsig).unwrap();
+        assert!(!String::from_utf8_lossy(&encoded).contains("arg"));
+
+        lsig.args = Some(vec![vec![], vec![1, 2]]);
+        let decoded: LogicSignature =
+            rmp_serde::from_slice(&rmp_serde::to_vec_named(&lsig).unwrap()).unwrap();
+        assert_eq!(decoded.args, Some(vec![vec![], vec![1, 2]]));
+    }
+
+    #[test]
+    fn round_trips_within_a_signed_transaction() {
+        let mut lsig = LogicSignature::new(PROGRAM.to_vec());
+        lsig.args = Some(vec![vec![1], vec![2]]);
+        lsig.logic_multisignature = Some(
+            multisig()
+                .apply_subsignature(AccountMother::account(), PLACEHOLDER_SIGNATURE)
+                .unwrap(),
+        );
+
+        let signed = SignedTransaction {
+            transaction: crate::test_utils::TransactionMother::simple_payment()
+                .build()
+                .unwrap(),
+            signature: None,
+            auth_address: None,
+            multisignature: None,
+            logic_signature: Some(lsig.clone()),
+        };
+
+        let decoded = SignedTransaction::decode(&signed.encode().unwrap()).unwrap();
+        assert_eq!(decoded.logic_signature, Some(lsig));
+    }
+
+    #[test]
+    fn rejects_an_empty_program() {
+        assert!(LogicSignature::new(vec![]).validate().is_err());
+    }
+
+    #[test]
+    fn rejects_multiple_delegations() {
+        let mut lsig = LogicSignature::new(PROGRAM.to_vec());
+        lsig.signature = Some(PLACEHOLDER_SIGNATURE);
+        lsig.logic_multisignature = Some(multisig());
+
+        assert!(lsig.validate().is_err());
+    }
+}

--- a/crates/algokit_transact/src/logic_sig.rs
+++ b/crates/algokit_transact/src/logic_sig.rs
@@ -2,8 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{Bytes, serde_as};
 
 use crate::constants::{
-    ALGORAND_SIGNATURE_BYTE_LENGTH, MAX_LOGIC_SIG_SIZE, MULTISIG_PROGRAM_DOMAIN_SEPARATOR,
-    PROGRAM_DOMAIN_SEPARATOR,
+    ALGORAND_SIGNATURE_BYTE_LENGTH, MULTISIG_PROGRAM_DOMAIN_SEPARATOR, PROGRAM_DOMAIN_SEPARATOR,
 };
 use crate::traits::Validate;
 use crate::utils::{hash, is_empty_signature_opt, is_empty_vec_opt};
@@ -100,14 +99,6 @@ impl Validate for LogicSignature {
             errors.push("LogicSig program cannot be empty".to_string());
         }
 
-        if self.logic.len() > MAX_LOGIC_SIG_SIZE {
-            errors.push(format!(
-                "LogicSig program of {} bytes exceeds the maximum of {} bytes",
-                self.logic.len(),
-                MAX_LOGIC_SIG_SIZE
-            ));
-        }
-
         let delegations = [
             self.signature.is_some(),
             self.multisignature.is_some(),
@@ -119,6 +110,12 @@ impl Validate for LogicSignature {
 
         if delegations > 1 {
             errors.push("LogicSig can carry at most one delegation signature".to_string());
+        }
+
+        if self.multisignature.is_some() {
+            errors.push(
+                "LogicSig msig delegation is rejected since consensus v41; use lmsig".to_string(),
+            );
         }
 
         if errors.is_empty() {
@@ -248,5 +245,49 @@ mod tests {
         lsig.logic_multisignature = Some(multisig());
 
         assert!(lsig.validate().is_err());
+    }
+}
+
+#[cfg(test)]
+mod msig_rejection_tests {
+    use super::*;
+    use crate::test_utils::AccountMother;
+
+    fn multisig() -> MultisigSignature {
+        MultisigSignature::from_participants(
+            1,
+            2,
+            vec![AccountMother::account(), AccountMother::neil()],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn rejects_legacy_msig_delegation() {
+        let mut lsig = LogicSignature::new(vec![1, 32, 1, 1, 34]);
+        lsig.multisignature = Some(multisig());
+
+        assert!(lsig.validate().is_err());
+    }
+
+    #[test]
+    fn accepts_lmsig_delegation() {
+        let mut lsig = LogicSignature::new(vec![1, 32, 1, 1, 34]);
+        lsig.logic_multisignature = Some(multisig());
+
+        assert!(lsig.validate().is_ok());
+    }
+
+    /// Validation rejects msig, but decoding must still accept it so pre-v41
+    /// transactions round-trip.
+    #[test]
+    fn legacy_msig_still_round_trips() {
+        let mut lsig = LogicSignature::new(vec![1, 32, 1, 1, 34]);
+        lsig.multisignature = Some(multisig());
+
+        let decoded: LogicSignature =
+            rmp_serde::from_slice(&rmp_serde::to_vec_named(&lsig).unwrap()).unwrap();
+
+        assert_eq!(decoded, lsig);
     }
 }

--- a/crates/algokit_transact/src/multisig.rs
+++ b/crates/algokit_transact/src/multisig.rs
@@ -10,7 +10,7 @@
 //! a cryptographic hash function.
 
 use crate::address::Address;
-use crate::utils::hash;
+use crate::utils::{hash, is_empty_signature_opt};
 use crate::{
     ALGORAND_PUBLIC_KEY_BYTE_LENGTH, ALGORAND_SIGNATURE_BYTE_LENGTH, AlgoKitTransactError,
     MULTISIG_DOMAIN_SEPARATOR,
@@ -202,9 +202,9 @@ pub struct MultisigSubsignature {
     /// Address of a keypair account participant that is sub-signing a multisignature transaction.
     #[serde(rename = "pk")]
     pub address: Address,
-    /// The signature bytes.
+    /// The signature bytes. An all-zero signature encodes as absent.
     #[serde(rename = "s")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_empty_signature_opt")]
     #[serde_as(as = "Option<Bytes>")]
     pub signature: Option<[u8; ALGORAND_SIGNATURE_BYTE_LENGTH]>,
 }

--- a/crates/algokit_transact/src/signer.rs
+++ b/crates/algokit_transact/src/signer.rs
@@ -54,6 +54,7 @@ impl TransactionSigner for EmptyTransactionSigner {
                         auth_address: None,
                         signature: Some(EMPTY_SIGNATURE),
                         multisignature: None,
+                        logic_signature: None,
                     }
                 } else {
                     // Return completely unsigned for transactions we weren't asked to sign
@@ -62,6 +63,7 @@ impl TransactionSigner for EmptyTransactionSigner {
                         auth_address: None,
                         signature: None,
                         multisignature: None,
+                        logic_signature: None,
                     }
                 }
             })
@@ -144,6 +146,7 @@ impl TransactionSigner for AlgorandSigner {
                     auth_address: self.auth_addr.clone(),
                     signature: Some(signature),
                     multisignature: None,
+                    logic_signature: None,
                 });
             } else {
                 // Transaction not meant to be signed by this signer
@@ -152,6 +155,7 @@ impl TransactionSigner for AlgorandSigner {
                     auth_address: None,
                     signature: None,
                     multisignature: None,
+                    logic_signature: None,
                 });
             }
         }

--- a/crates/algokit_transact/src/signer.rs
+++ b/crates/algokit_transact/src/signer.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Address, AlgoKitTransactError, SignedTransaction, Transaction, traits::AlgorandMsgpack,
+    Address, AlgoKitTransactError, EMPTY_SIGNATURE, SignedTransaction, Transaction,
+    traits::AlgorandMsgpack,
 };
 use algokit_crypto::ed25519::Ed25519KeyAndSigner;
 use async_trait::async_trait;
@@ -51,7 +52,7 @@ impl TransactionSigner for EmptyTransactionSigner {
                     SignedTransaction {
                         transaction: txn.clone(),
                         auth_address: None,
-                        signature: Some([0u8; 64]),
+                        signature: Some(EMPTY_SIGNATURE),
                         multisignature: None,
                     }
                 } else {

--- a/crates/algokit_transact/src/test_utils/mod.rs
+++ b/crates/algokit_transact/src/test_utils/mod.rs
@@ -6,12 +6,16 @@ mod key_registration;
 mod state_proof;
 
 use crate::{
-    ALGORAND_PUBLIC_KEY_BYTE_LENGTH, Address, AlgorandMsgpack, Byte32, EMPTY_SIGNATURE,
-    HASH_BYTES_LENGTH, MultisigSignature, MultisigSubsignature, SignedTransaction, Transaction,
-    TransactionHeaderBuilder, TransactionId,
+    ALGORAND_PUBLIC_KEY_BYTE_LENGTH, ALGORAND_SIGNATURE_BYTE_LENGTH, Address, AlgorandMsgpack,
+    Byte32, HASH_BYTES_LENGTH, MultisigSignature, MultisigSubsignature, SignedTransaction,
+    Transaction, TransactionHeaderBuilder, TransactionId,
     test_utils::state_proof::StateProofTransactionMother,
     transactions::{AssetTransferTransactionBuilder, PaymentTransactionBuilder},
 };
+
+/// Placeholder signature for encoding tests. Not all-zero, which would encode as absent.
+pub const PLACEHOLDER_SIGNATURE: [u8; ALGORAND_SIGNATURE_BYTE_LENGTH] =
+    [1u8; ALGORAND_SIGNATURE_BYTE_LENGTH];
 use base64::{Engine, prelude::BASE64_STANDARD};
 use convert_case::{Case, Casing};
 use ed25519_dalek::{Signer, SigningKey};
@@ -569,7 +573,7 @@ pub fn check_transaction_encoding(tx: &Transaction, expected_encoded_len: usize)
 
     let signed_tx = SignedTransaction {
         transaction: tx.clone(),
-        signature: Some(EMPTY_SIGNATURE),
+        signature: Some(PLACEHOLDER_SIGNATURE),
         auth_address: None,
         multisignature: None,
     };
@@ -593,7 +597,7 @@ pub fn check_signed_transaction_encoding(
 ) {
     let signed_tx = SignedTransaction {
         transaction: tx.clone(),
-        signature: Some(EMPTY_SIGNATURE),
+        signature: Some(PLACEHOLDER_SIGNATURE),
         auth_address: auth_account,
         multisignature: None,
     };
@@ -611,10 +615,10 @@ pub fn check_multisigned_transaction_encoding(tx: &Transaction, expected_encoded
     )
     .unwrap();
     let multisignature_0 = unsigned_multisignature
-        .apply_subsignature(AccountMother::account(), EMPTY_SIGNATURE)
+        .apply_subsignature(AccountMother::account(), PLACEHOLDER_SIGNATURE)
         .unwrap();
     let multisignature_1 = unsigned_multisignature
-        .apply_subsignature(AccountMother::neil(), EMPTY_SIGNATURE)
+        .apply_subsignature(AccountMother::neil(), PLACEHOLDER_SIGNATURE)
         .unwrap();
     let multisignature = Some(multisignature_0.merge(&multisignature_1).unwrap());
     let signed_tx = SignedTransaction {
@@ -632,7 +636,7 @@ pub fn check_multisigned_transaction_encoding(tx: &Transaction, expected_encoded
 pub fn check_transaction_id(tx: &Transaction, expected_tx_id: &str) {
     let signed_tx = SignedTransaction {
         transaction: tx.clone(),
-        signature: Some(EMPTY_SIGNATURE),
+        signature: Some(PLACEHOLDER_SIGNATURE),
         auth_address: None,
         multisignature: None,
     };

--- a/crates/algokit_transact/src/test_utils/mod.rs
+++ b/crates/algokit_transact/src/test_utils/mod.rs
@@ -328,6 +328,7 @@ impl TransactionTestData {
             signature: Some(signature.to_bytes()),
             auth_address: None,
             multisignature: None,
+            logic_signature: None,
         };
         let signed_bytes = signed_txn.encode().unwrap();
 
@@ -339,6 +340,7 @@ impl TransactionTestData {
             signature: Some(signature.to_bytes()),
             auth_address: Some(rekeyed_sender_auth_address.clone()),
             multisignature: None,
+            logic_signature: None,
         };
         let rekeyed_sender_signed_bytes = signer_signed_txn.encode().unwrap();
 
@@ -369,6 +371,7 @@ impl TransactionTestData {
             signature: None,
             auth_address: None,
             multisignature: Some(multisig_signature),
+            logic_signature: None,
         };
         let multisig_signed_bytes = multisig_signed_txn.encode().unwrap();
 
@@ -576,6 +579,7 @@ pub fn check_transaction_encoding(tx: &Transaction, expected_encoded_len: usize)
         signature: Some(PLACEHOLDER_SIGNATURE),
         auth_address: None,
         multisignature: None,
+        logic_signature: None,
     };
     let encoded_stx = signed_tx.encode().unwrap();
     let decoded_stx = SignedTransaction::decode(&encoded_stx).unwrap();
@@ -600,6 +604,7 @@ pub fn check_signed_transaction_encoding(
         signature: Some(PLACEHOLDER_SIGNATURE),
         auth_address: auth_account,
         multisignature: None,
+        logic_signature: None,
     };
     let encoded_stx = signed_tx.encode().unwrap();
     assert_eq!(encoded_stx.len(), expected_encoded_len);
@@ -626,6 +631,7 @@ pub fn check_multisigned_transaction_encoding(tx: &Transaction, expected_encoded
         signature: None,
         auth_address: None,
         multisignature,
+        logic_signature: None,
     };
     let encoded_stx = signed_tx.encode().unwrap();
     assert_eq!(encoded_stx.len(), expected_encoded_len);
@@ -639,6 +645,7 @@ pub fn check_transaction_id(tx: &Transaction, expected_tx_id: &str) {
         signature: Some(PLACEHOLDER_SIGNATURE),
         auth_address: None,
         multisignature: None,
+        logic_signature: None,
     };
 
     assert_eq!(tx.id().unwrap(), expected_tx_id);

--- a/crates/algokit_transact/src/transactions/app_call.rs
+++ b/crates/algokit_transact/src/transactions/app_call.rs
@@ -7,9 +7,10 @@ use crate::traits::{MsgPackEmpty, Validate};
 use crate::transactions::common::{TransactionHeader, TransactionValidationError};
 use crate::utils::{is_empty_struct_opt, is_empty_vec_opt, is_zero, is_zero_opt};
 use crate::{
-    Address, MAX_ACCOUNT_REFERENCES, MAX_APP_ARGS, MAX_APP_REFERENCES, MAX_ARGS_SIZE,
-    MAX_ASSET_REFERENCES, MAX_BOX_REFERENCES, MAX_EXTRA_PROGRAM_PAGES, MAX_GLOBAL_STATE_KEYS,
-    MAX_LOCAL_STATE_KEYS, MAX_OVERALL_REFERENCES, PROGRAM_PAGE_SIZE, Transaction,
+    Address, MAX_ACCESS_REFERENCES, MAX_ACCOUNT_REFERENCES, MAX_APP_ARGS, MAX_APP_REFERENCES,
+    MAX_ARGS_SIZE, MAX_ASSET_REFERENCES, MAX_BOX_REFERENCES, MAX_EXTRA_PROGRAM_PAGES,
+    MAX_GLOBAL_STATE_KEYS, MAX_LOCAL_STATE_KEYS, MAX_OVERALL_REFERENCES, PROGRAM_PAGE_SIZE,
+    Transaction,
 };
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
@@ -238,6 +239,114 @@ pub struct AppCallTransactionFields {
     #[serde(default)]
     #[builder(default)]
     pub box_references: Option<Vec<BoxReference>>,
+
+    /// The unified access list, replacing the separate reference arrays above.
+    /// Mutually exclusive with them.
+    #[serde(rename = "al")]
+    #[serde(skip_serializing_if = "is_empty_vec_opt")]
+    #[serde(default)]
+    #[builder(default)]
+    pub access: Option<Vec<ResourceRef>>,
+}
+
+/// A single entry in an app call's access list.
+///
+/// At most one field is set. An entry with none set bumps the box read/write quota.
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+pub struct ResourceRef {
+    /// An account made available to the program.
+    #[serde(rename = "d")]
+    #[serde(default)]
+    pub address: Option<Address>,
+
+    /// An asset made available to the program.
+    #[serde(rename = "s")]
+    #[serde(skip_serializing_if = "is_zero_opt")]
+    #[serde(default)]
+    pub asset: Option<u64>,
+
+    /// An app made available to the program.
+    #[serde(rename = "p")]
+    #[serde(skip_serializing_if = "is_zero_opt")]
+    #[serde(default)]
+    pub app: Option<u64>,
+
+    /// An asset holding, naming an account and an asset already in the access list.
+    #[serde(rename = "h")]
+    #[serde(default)]
+    pub holding: Option<HoldingRef>,
+
+    /// An account's local state for an app, both already in the access list.
+    #[serde(rename = "l")]
+    #[serde(default)]
+    pub locals: Option<LocalsRef>,
+
+    /// A box owned by an app in the access list. `app_id` here is a 1-based index into
+    /// the access list, not an app ID.
+    #[serde(rename = "b")]
+    #[serde(default)]
+    pub box_ref: Option<BoxReference>,
+}
+
+/// An asset holding, by position within the access list.
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+pub struct HoldingRef {
+    /// 0 is the sender, otherwise a 1-based index into the access list.
+    #[serde(rename = "d")]
+    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(default)]
+    pub address: u64,
+
+    /// A 1-based index into the access list.
+    #[serde(rename = "s")]
+    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(default)]
+    pub asset: u64,
+}
+
+/// An account's local state for an app, by position within the access list.
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+pub struct LocalsRef {
+    /// 0 is the sender, otherwise a 1-based index into the access list.
+    #[serde(rename = "d")]
+    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(default)]
+    pub address: u64,
+
+    /// 0 is the app being called, otherwise a 1-based index into the access list.
+    #[serde(rename = "p")]
+    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(default)]
+    pub app: u64,
+}
+
+impl ResourceRef {
+    /// Whether no resource is named. Empty entries bump the box quota.
+    pub fn is_empty(&self) -> bool {
+        self.address.is_none()
+            && self.asset.is_none()
+            && self.app.is_none()
+            && self.holding.is_none()
+            && self.locals.is_none()
+            && self.box_ref.is_none()
+    }
+
+    fn named_count(&self) -> usize {
+        [
+            self.address.is_some(),
+            self.asset.is_some(),
+            self.app.is_some(),
+            self.holding.is_some(),
+            self.locals.is_some(),
+            self.box_ref.is_some(),
+        ]
+        .iter()
+        .filter(|set| **set)
+        .count()
+    }
 }
 
 fn is_default_on_complete(on_complete: &OnApplicationComplete) -> bool {
@@ -556,6 +665,41 @@ impl AppCallTransactionFields {
                     max: MAX_ARGS_SIZE,
                     unit: "bytes".to_string(),
                 });
+            }
+        }
+
+        // Validate the unified access list
+        if let Some(ref access) = self.access {
+            if access.len() > MAX_ACCESS_REFERENCES {
+                errors.push(TransactionValidationError::FieldTooLong {
+                    field: "Access".to_string(),
+                    actual: access.len(),
+                    max: MAX_ACCESS_REFERENCES,
+                    unit: "refs".to_string(),
+                });
+            }
+
+            if access.iter().any(|entry| entry.named_count() > 1) {
+                errors.push(TransactionValidationError::ArbitraryConstraint(
+                    "Each Access entry may name at most one resource".to_string(),
+                ));
+            }
+
+            let legacy_refs_present = self
+                .account_references
+                .as_ref()
+                .is_some_and(|r| !r.is_empty())
+                || self.app_references.as_ref().is_some_and(|r| !r.is_empty())
+                || self
+                    .asset_references
+                    .as_ref()
+                    .is_some_and(|r| !r.is_empty())
+                || self.box_references.as_ref().is_some_and(|r| !r.is_empty());
+
+            if legacy_refs_present {
+                errors.push(TransactionValidationError::ArbitraryConstraint(
+                    "Access cannot be combined with the separate reference arrays".to_string(),
+                ));
             }
         }
 
@@ -1360,5 +1504,169 @@ mod tests {
             data.id,
             String::from("XVVC7UDLCPI622KCJZLWK3SEAWWVUEPEXUM5CO3DFLWOBH7NOPDQ")
         );
+    }
+}
+
+#[cfg(test)]
+mod access_tests {
+    use super::*;
+    use crate::AlgorandMsgpack;
+    use crate::test_utils::{AccountMother, AppCallTransactionMother};
+
+    fn app_call_with_access(access: Vec<ResourceRef>) -> AppCallTransactionFields {
+        let mut fields = AppCallTransactionMother::app_call().build_fields().unwrap();
+        fields.account_references = None;
+        fields.app_references = None;
+        fields.asset_references = None;
+        fields.box_references = None;
+        fields.access = Some(access);
+        fields
+    }
+
+    fn map_keys(value: &rmpv::Value) -> Vec<String> {
+        match value {
+            rmpv::Value::Map(entries) => entries
+                .iter()
+                .filter_map(|(k, _)| k.as_str().map(str::to_string))
+                .collect(),
+            other => panic!("expected a msgpack map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn access_entries_encode_with_the_expected_tags() {
+        let access = vec![
+            ResourceRef {
+                address: Some(AccountMother::neil()),
+                ..Default::default()
+            },
+            ResourceRef {
+                asset: Some(107686045),
+                ..Default::default()
+            },
+            ResourceRef {
+                app: Some(1234),
+                ..Default::default()
+            },
+            ResourceRef {
+                holding: Some(HoldingRef {
+                    address: 1,
+                    asset: 2,
+                }),
+                ..Default::default()
+            },
+            ResourceRef {
+                locals: Some(LocalsRef { address: 1, app: 3 }),
+                ..Default::default()
+            },
+            ResourceRef {
+                box_ref: Some(BoxReference {
+                    app_id: 3,
+                    name: b"box".to_vec(),
+                }),
+                ..Default::default()
+            },
+        ];
+
+        let encoded = rmp_serde::to_vec_named(&access).unwrap();
+        let decoded: rmpv::Value = rmp_serde::from_slice(&encoded).unwrap();
+        let entries = match decoded {
+            rmpv::Value::Array(entries) => entries,
+            other => panic!("expected an array, got {other:?}"),
+        };
+
+        assert_eq!(map_keys(&entries[0]), vec!["d"]);
+        assert_eq!(map_keys(&entries[1]), vec!["s"]);
+        assert_eq!(map_keys(&entries[2]), vec!["p"]);
+        assert_eq!(map_keys(&entries[3]), vec!["h"]);
+        assert_eq!(map_keys(&entries[4]), vec!["l"]);
+        assert_eq!(map_keys(&entries[5]), vec!["b"]);
+    }
+
+    #[test]
+    fn an_empty_entry_encodes_as_an_empty_map() {
+        let encoded = rmp_serde::to_vec_named(&ResourceRef::default()).unwrap();
+        let decoded: rmpv::Value = rmp_serde::from_slice(&encoded).unwrap();
+
+        assert!(ResourceRef::default().is_empty());
+        assert_eq!(map_keys(&decoded), Vec::<String>::new());
+    }
+
+    #[test]
+    fn access_round_trips_through_a_transaction() {
+        let fields = app_call_with_access(vec![
+            ResourceRef {
+                address: Some(AccountMother::neil()),
+                ..Default::default()
+            },
+            ResourceRef {
+                box_ref: Some(BoxReference {
+                    app_id: 1,
+                    name: b"b".to_vec(),
+                }),
+                ..Default::default()
+            },
+        ]);
+        let txn = Transaction::AppCall(fields.clone());
+
+        let decoded = Transaction::decode(&txn.encode().unwrap()).unwrap();
+
+        match decoded {
+            Transaction::AppCall(decoded) => assert_eq!(decoded.access, fields.access),
+            other => panic!("expected an app call, got {other:?}"),
+        }
+    }
+
+    /// Access box refs index the access list, so the legacy app-id rewrite must not
+    /// touch them.
+    #[test]
+    fn access_box_refs_are_not_rewritten() {
+        let fields = app_call_with_access(vec![ResourceRef {
+            box_ref: Some(BoxReference {
+                app_id: 2,
+                name: b"b".to_vec(),
+            }),
+            ..Default::default()
+        }]);
+
+        let txn = Transaction::AppCall(fields);
+        let decoded = Transaction::decode(&txn.encode().unwrap()).unwrap();
+
+        match decoded {
+            Transaction::AppCall(decoded) => {
+                let refs = decoded.access.unwrap();
+                assert_eq!(refs[0].box_ref.as_ref().unwrap().app_id, 2);
+            }
+            other => panic!("expected an app call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_an_entry_naming_more_than_one_resource() {
+        let fields = app_call_with_access(vec![ResourceRef {
+            asset: Some(1),
+            app: Some(2),
+            ..Default::default()
+        }]);
+
+        assert!(fields.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_access_combined_with_legacy_reference_arrays() {
+        let mut fields = app_call_with_access(vec![ResourceRef {
+            asset: Some(1),
+            ..Default::default()
+        }]);
+        fields.asset_references = Some(vec![2]);
+
+        assert!(fields.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_more_entries_than_the_bound() {
+        let fields = app_call_with_access(vec![ResourceRef::default(); MAX_ACCESS_REFERENCES + 1]);
+
+        assert!(fields.validate().is_err());
     }
 }

--- a/crates/algokit_transact/src/transactions/app_call.rs
+++ b/crates/algokit_transact/src/transactions/app_call.rs
@@ -349,6 +349,54 @@ impl ResourceRef {
     }
 }
 
+/// Checks each access index is in bounds and names the right kind of entry.
+/// Index 0 means the sender, or the app being called.
+fn validate_access_indices(access: &[ResourceRef]) -> Vec<TransactionValidationError> {
+    let mut errors = Vec::new();
+
+    let describe = |index: u64, expected: &str| {
+        TransactionValidationError::ArbitraryConstraint(format!(
+            "Access index {} must refer to {}",
+            index, expected
+        ))
+    };
+
+    let resolves_to = |index: u64, want: fn(&ResourceRef) -> bool| -> bool {
+        match access.get(index as usize - 1) {
+            Some(entry) => want(entry),
+            None => false,
+        }
+    };
+
+    for entry in access {
+        if let Some(ref holding) = entry.holding {
+            if holding.address != 0 && !resolves_to(holding.address, |e| e.address.is_some()) {
+                errors.push(describe(holding.address, "an Address in the Access list"));
+            }
+            if holding.asset == 0 || !resolves_to(holding.asset, |e| e.asset.is_some()) {
+                errors.push(describe(holding.asset, "an Asset in the Access list"));
+            }
+        }
+
+        if let Some(ref locals) = entry.locals {
+            if locals.address != 0 && !resolves_to(locals.address, |e| e.address.is_some()) {
+                errors.push(describe(locals.address, "an Address in the Access list"));
+            }
+            if locals.app != 0 && !resolves_to(locals.app, |e| e.app.is_some()) {
+                errors.push(describe(locals.app, "an App in the Access list"));
+            }
+        }
+
+        if let Some(ref box_ref) = entry.box_ref {
+            if box_ref.app_id != 0 && !resolves_to(box_ref.app_id, |e| e.app.is_some()) {
+                errors.push(describe(box_ref.app_id, "an App in the Access list"));
+            }
+        }
+    }
+
+    errors
+}
+
 fn is_default_on_complete(on_complete: &OnApplicationComplete) -> bool {
     matches!(on_complete, OnApplicationComplete::NoOp)
 }
@@ -684,6 +732,8 @@ impl AppCallTransactionFields {
                     "Each Access entry may name at most one resource".to_string(),
                 ));
             }
+
+            errors.extend(validate_access_indices(access));
 
             let legacy_refs_present = self
                 .account_references
@@ -1666,6 +1716,155 @@ mod access_tests {
     #[test]
     fn rejects_more_entries_than_the_bound() {
         let fields = app_call_with_access(vec![ResourceRef::default(); MAX_ACCESS_REFERENCES + 1]);
+
+        assert!(fields.validate().is_err());
+    }
+}
+
+#[cfg(test)]
+mod access_index_tests {
+    use super::*;
+    use crate::test_utils::{AccountMother, AppCallTransactionMother};
+
+    fn with_access(access: Vec<ResourceRef>) -> AppCallTransactionFields {
+        let mut fields = AppCallTransactionMother::app_call().build_fields().unwrap();
+        fields.account_references = None;
+        fields.app_references = None;
+        fields.asset_references = None;
+        fields.box_references = None;
+        fields.access = Some(access);
+        fields
+    }
+
+    fn address_entry() -> ResourceRef {
+        ResourceRef {
+            address: Some(AccountMother::neil()),
+            ..Default::default()
+        }
+    }
+
+    fn asset_entry() -> ResourceRef {
+        ResourceRef {
+            asset: Some(107686045),
+            ..Default::default()
+        }
+    }
+
+    fn app_entry() -> ResourceRef {
+        ResourceRef {
+            app: Some(1234),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn accepts_indices_pointing_at_the_right_kinds() {
+        let fields = with_access(vec![
+            address_entry(),
+            asset_entry(),
+            app_entry(),
+            ResourceRef {
+                holding: Some(HoldingRef {
+                    address: 1,
+                    asset: 2,
+                }),
+                ..Default::default()
+            },
+            ResourceRef {
+                locals: Some(LocalsRef { address: 1, app: 3 }),
+                ..Default::default()
+            },
+        ]);
+
+        assert!(fields.validate().is_ok());
+    }
+
+    /// 0 is valid, not out of bounds.
+    #[test]
+    fn accepts_zero_as_sender_or_current_app() {
+        let fields = with_access(vec![
+            asset_entry(),
+            ResourceRef {
+                holding: Some(HoldingRef {
+                    address: 0,
+                    asset: 1,
+                }),
+                ..Default::default()
+            },
+            ResourceRef {
+                locals: Some(LocalsRef { address: 0, app: 0 }),
+                ..Default::default()
+            },
+            ResourceRef {
+                box_ref: Some(BoxReference {
+                    app_id: 0,
+                    name: b"b".to_vec(),
+                }),
+                ..Default::default()
+            },
+        ]);
+
+        assert!(fields.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_an_index_beyond_the_list() {
+        let fields = with_access(vec![
+            asset_entry(),
+            ResourceRef {
+                holding: Some(HoldingRef {
+                    address: 0,
+                    asset: 9,
+                }),
+                ..Default::default()
+            },
+        ]);
+
+        assert!(fields.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_an_index_pointing_at_the_wrong_kind() {
+        // The holding's asset index points at an Address entry, not an Asset.
+        let fields = with_access(vec![
+            address_entry(),
+            ResourceRef {
+                holding: Some(HoldingRef {
+                    address: 0,
+                    asset: 1,
+                }),
+                ..Default::default()
+            },
+        ]);
+
+        assert!(fields.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_a_holding_without_an_asset() {
+        let fields = with_access(vec![ResourceRef {
+            holding: Some(HoldingRef {
+                address: 0,
+                asset: 0,
+            }),
+            ..Default::default()
+        }]);
+
+        assert!(fields.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_a_box_index_pointing_at_a_non_app() {
+        let fields = with_access(vec![
+            asset_entry(),
+            ResourceRef {
+                box_ref: Some(BoxReference {
+                    app_id: 1,
+                    name: b"b".to_vec(),
+                }),
+                ..Default::default()
+            },
+        ]);
 
         assert!(fields.validate().is_err());
     }

--- a/crates/algokit_transact/src/transactions/key_registration.rs
+++ b/crates/algokit_transact/src/transactions/key_registration.rs
@@ -413,6 +413,7 @@ mod tests {
             signature: Some(PLACEHOLDER_SIGNATURE),
             auth_address: None,
             multisignature: None,
+            logic_signature: None,
         };
         let encoded_stx = signed_tx.encode().unwrap();
         let decoded_stx = SignedTransaction::decode(&encoded_stx).unwrap();
@@ -444,6 +445,7 @@ mod tests {
             signature: Some(PLACEHOLDER_SIGNATURE),
             auth_address: None,
             multisignature: None,
+            logic_signature: None,
         };
         let encoded_stx = signed_tx.encode().unwrap();
         let decoded_stx = SignedTransaction::decode(&encoded_stx).unwrap();
@@ -476,6 +478,7 @@ mod tests {
             signature: Some(PLACEHOLDER_SIGNATURE),
             auth_address: None,
             multisignature: None,
+            logic_signature: None,
         };
 
         // Test that transaction ID can be generated

--- a/crates/algokit_transact/src/transactions/key_registration.rs
+++ b/crates/algokit_transact/src/transactions/key_registration.rs
@@ -179,7 +179,7 @@ mod tests {
     };
     use crate::{
         AlgorandMsgpack, SignedTransaction, Transaction, Transactions,
-        constants::EMPTY_SIGNATURE,
+        test_utils::PLACEHOLDER_SIGNATURE,
         test_utils::{AccountMother, TransactionMother},
         traits::TransactionId,
         transactions::FeeParams,
@@ -410,7 +410,7 @@ mod tests {
 
         let signed_tx = SignedTransaction {
             transaction: key_reg_tx.clone(),
-            signature: Some(EMPTY_SIGNATURE),
+            signature: Some(PLACEHOLDER_SIGNATURE),
             auth_address: None,
             multisignature: None,
         };
@@ -441,7 +441,7 @@ mod tests {
 
         let signed_tx = SignedTransaction {
             transaction: key_reg_tx.clone(),
-            signature: Some(EMPTY_SIGNATURE),
+            signature: Some(PLACEHOLDER_SIGNATURE),
             auth_address: None,
             multisignature: None,
         };
@@ -473,7 +473,7 @@ mod tests {
 
         let signed_tx = SignedTransaction {
             transaction: key_reg_tx.clone(),
-            signature: Some(EMPTY_SIGNATURE),
+            signature: Some(PLACEHOLDER_SIGNATURE),
             auth_address: None,
             multisignature: None,
         };

--- a/crates/algokit_transact/src/transactions/mod.rs
+++ b/crates/algokit_transact/src/transactions/mod.rs
@@ -15,8 +15,8 @@ mod payment;
 pub mod state_proof;
 
 pub use app_call::{
-    AppCallTransactionBuilder, AppCallTransactionFields, BoxReference, OnApplicationComplete,
-    StateSchema,
+    AppCallTransactionBuilder, AppCallTransactionFields, BoxReference, HoldingRef, LocalsRef,
+    OnApplicationComplete, ResourceRef, StateSchema,
 };
 use app_call::{app_call_deserializer, app_call_serializer};
 pub use asset_config::{
@@ -367,6 +367,7 @@ mod transaction_tests {
             app_references: None,
             asset_references: None,
             box_references: None,
+            access: None,
         });
 
         // Test pattern matching for app call
@@ -422,6 +423,7 @@ mod transaction_tests {
                 app_references: None,
                 asset_references: None,
                 box_references: None,
+                access: None,
             }),
         ];
 

--- a/crates/algokit_transact/src/transactions/mod.rs
+++ b/crates/algokit_transact/src/transactions/mod.rs
@@ -44,7 +44,7 @@ use crate::constants::{
 use crate::error::AlgoKitTransactError;
 use crate::traits::{AlgorandMsgpack, EstimateTransactionSize, TransactionId, Transactions};
 use crate::utils::{compute_group, is_empty_signature_opt, is_zero_addr_opt};
-use crate::{Address, MultisigSignature};
+use crate::{Address, LogicSignature, MultisigSignature};
 use serde::{Deserialize, Serialize};
 use serde_with::{Bytes, serde_as};
 use std::any::Any;
@@ -194,6 +194,12 @@ pub struct SignedTransaction {
     #[serde(rename = "msig")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multisignature: Option<MultisigSignature>,
+
+    /// Optional logic signature authorizing the transaction with a program.
+    #[serde(rename = "lsig")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub logic_signature: Option<LogicSignature>,
 }
 
 impl AlgorandMsgpack for SignedTransaction {
@@ -622,6 +628,7 @@ mod transaction_tests {
                 signature: Some(PLACEHOLDER_SIGNATURE),
                 auth_address: None,
                 multisignature: None,
+                logic_signature: None,
             })
             .collect::<Vec<SignedTransaction>>();
 
@@ -652,6 +659,7 @@ mod transaction_tests {
             signature,
             auth_address: None,
             multisignature: None,
+            logic_signature: None,
         }
     }
 

--- a/crates/algokit_transact/src/transactions/mod.rs
+++ b/crates/algokit_transact/src/transactions/mod.rs
@@ -43,7 +43,7 @@ use crate::constants::{
 };
 use crate::error::AlgoKitTransactError;
 use crate::traits::{AlgorandMsgpack, EstimateTransactionSize, TransactionId, Transactions};
-use crate::utils::{compute_group, is_zero_addr_opt};
+use crate::utils::{compute_group, is_empty_signature_opt, is_zero_addr_opt};
 use crate::{Address, MultisigSignature};
 use serde::{Deserialize, Serialize};
 use serde_with::{Bytes, serde_as};
@@ -178,9 +178,9 @@ pub struct SignedTransaction {
     #[serde(rename = "txn")]
     pub transaction: Transaction,
 
-    /// Optional Ed25519 signature authorizing the transaction.
+    /// Optional Ed25519 signature authorizing the transaction. All-zero encodes as absent.
     #[serde(rename = "sig")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_empty_signature_opt")]
     #[serde_as(as = "Option<Bytes>")]
     pub signature: Option<[u8; ALGORAND_SIGNATURE_BYTE_LENGTH]>,
 
@@ -305,6 +305,7 @@ impl Transaction {
 mod transaction_tests {
     use crate::{
         EMPTY_SIGNATURE, MAX_TX_GROUP_SIZE,
+        test_utils::PLACEHOLDER_SIGNATURE,
         test_utils::{TransactionGroupMother, TransactionHeaderMother, TransactionMother},
     };
     use base64::{Engine, prelude::BASE64_STANDARD};
@@ -618,7 +619,7 @@ mod transaction_tests {
             .iter()
             .map(|tx| SignedTransaction {
                 transaction: tx.clone(),
-                signature: Some(EMPTY_SIGNATURE),
+                signature: Some(PLACEHOLDER_SIGNATURE),
                 auth_address: None,
                 multisignature: None,
             })
@@ -643,5 +644,50 @@ mod transaction_tests {
             assert_eq!(encoded_signed_tx, signed_grouped_tx.encode().unwrap());
             assert_eq!(decoded_signed_tx, signed_grouped_tx);
         }
+    }
+
+    fn signed_with(signature: Option<[u8; ALGORAND_SIGNATURE_BYTE_LENGTH]>) -> SignedTransaction {
+        SignedTransaction {
+            transaction: TransactionMother::simple_payment().build().unwrap(),
+            signature,
+            auth_address: None,
+            multisignature: None,
+        }
+    }
+
+    #[test]
+    fn zero_signature_encodes_the_same_as_an_absent_one() {
+        let zeroed = signed_with(Some(EMPTY_SIGNATURE)).encode().unwrap();
+        let absent = signed_with(None).encode().unwrap();
+
+        assert_eq!(zeroed, absent);
+    }
+
+    #[test]
+    fn zero_signature_does_not_emit_a_sig_key() {
+        let encoded = signed_with(Some(EMPTY_SIGNATURE)).encode_raw().unwrap();
+        let value: rmpv::Value = rmp_serde::from_slice(&encoded).unwrap();
+
+        let keys: Vec<String> = match value {
+            rmpv::Value::Map(entries) => entries
+                .iter()
+                .filter_map(|(k, _)| k.as_str().map(str::to_string))
+                .collect(),
+            other => panic!("expected a msgpack map, got {other:?}"),
+        };
+
+        assert_eq!(keys, vec!["txn".to_string()]);
+    }
+
+    #[test]
+    fn a_real_signature_still_encodes() {
+        let signed = signed_with(Some(PLACEHOLDER_SIGNATURE));
+        let encoded = signed.encode().unwrap();
+
+        assert_ne!(encoded, signed_with(None).encode().unwrap());
+        assert_eq!(
+            SignedTransaction::decode(&encoded).unwrap().signature,
+            Some(PLACEHOLDER_SIGNATURE)
+        );
     }
 }

--- a/crates/algokit_transact/src/utils.rs
+++ b/crates/algokit_transact/src/utils.rs
@@ -1,5 +1,6 @@
 use crate::constants::{
-    ALGORAND_CHECKSUM_BYTE_LENGTH, ALGORAND_PUBLIC_KEY_BYTE_LENGTH, Byte32, HASH_BYTES_LENGTH,
+    ALGORAND_CHECKSUM_BYTE_LENGTH, ALGORAND_PUBLIC_KEY_BYTE_LENGTH, ALGORAND_SIGNATURE_BYTE_LENGTH,
+    Byte32, EMPTY_SIGNATURE, HASH_BYTES_LENGTH,
 };
 use crate::traits::MsgPackEmpty;
 use crate::{
@@ -239,6 +240,11 @@ pub fn is_zero_addr(addr: &Address) -> bool {
 
 pub fn is_zero_addr_opt(addr: &Option<Address>) -> bool {
     addr.as_ref().is_none_or(is_zero_addr)
+}
+
+/// An all-zero signature is the absent signature on the wire; go-algorand omits it.
+pub fn is_empty_signature_opt(signature: &Option<[u8; ALGORAND_SIGNATURE_BYTE_LENGTH]>) -> bool {
+    signature.as_ref().is_none_or(|sig| sig == &EMPTY_SIGNATURE)
 }
 
 pub fn is_empty_bytes32(bytes: &Byte32) -> bool {

--- a/crates/algokit_transact_ffi/src/lib.rs
+++ b/crates/algokit_transact_ffi/src/lib.rs
@@ -1,3 +1,4 @@
+mod logic_sig;
 mod multisig;
 mod signer;
 pub mod transactions;
@@ -9,6 +10,7 @@ use algokit_transact::{
 use ffi_macros::{ffi_enum, ffi_func, ffi_record};
 use serde::{Deserialize, Serialize};
 
+pub use logic_sig::*;
 pub use multisig::{MultisigSignature, MultisigSubsignature};
 pub use signer::ed25519_sign_transaction;
 pub use transactions::AppCallTransactionFields;
@@ -387,6 +389,9 @@ pub struct SignedTransaction {
 
     /// Optional multisig signature if the transaction is a multisig transaction.
     pub multisignature: Option<MultisigSignature>,
+
+    /// Optional logic signature authorizing the transaction with a program.
+    pub logic_signature: Option<LogicSignature>,
 }
 
 impl From<algokit_transact::SignedTransaction> for SignedTransaction {
@@ -396,6 +401,7 @@ impl From<algokit_transact::SignedTransaction> for SignedTransaction {
             signature: signed_transaction.signature.map(|sig| sig.into()),
             auth_address: signed_transaction.auth_address.map(|addr| addr.as_str()),
             multisignature: signed_transaction.multisignature.map(Into::into),
+            logic_signature: signed_transaction.logic_signature.map(Into::into),
         }
     }
 }
@@ -422,6 +428,10 @@ impl TryFrom<SignedTransaction> for algokit_transact::SignedTransaction {
                 .transpose()?,
             multisignature: signed_transaction
                 .multisignature
+                .map(TryInto::try_into)
+                .transpose()?,
+            logic_signature: signed_transaction
+                .logic_signature
                 .map(TryInto::try_into)
                 .transpose()?,
         })

--- a/crates/algokit_transact_ffi/src/logic_sig.rs
+++ b/crates/algokit_transact_ffi/src/logic_sig.rs
@@ -1,0 +1,91 @@
+use algokit_transact::Validate;
+use ffi_macros::{ffi_func, ffi_record};
+use serde::{Deserialize, Serialize};
+
+use crate::{AlgoKitTransactError, MultisigSignature, vec_to_array};
+
+/// Representation of an Algorand logic signature.
+#[ffi_record]
+pub struct LogicSignature {
+    /// The compiled program bytes.
+    pub logic: Vec<u8>,
+    /// Signature of an account delegating to this program.
+    pub signature: Option<Vec<u8>>,
+    /// Legacy multisig delegation, rejected by the network since consensus v41.
+    pub multisignature: Option<MultisigSignature>,
+    /// Multisig delegation, binding the signature to the delegating account.
+    pub logic_multisignature: Option<MultisigSignature>,
+    /// Arguments made available to the program.
+    pub args: Option<Vec<Vec<u8>>>,
+}
+
+impl From<algokit_transact::LogicSignature> for LogicSignature {
+    fn from(lsig: algokit_transact::LogicSignature) -> Self {
+        Self {
+            logic: lsig.logic,
+            signature: lsig.signature.map(|sig| sig.into()),
+            multisignature: lsig.multisignature.map(Into::into),
+            logic_multisignature: lsig.logic_multisignature.map(Into::into),
+            args: lsig.args,
+        }
+    }
+}
+
+impl TryFrom<LogicSignature> for algokit_transact::LogicSignature {
+    type Error = AlgoKitTransactError;
+
+    fn try_from(lsig: LogicSignature) -> Result<Self, Self::Error> {
+        Ok(Self {
+            logic: lsig.logic,
+            signature: lsig
+                .signature
+                .map(|sig| vec_to_array(&sig, "signature"))
+                .transpose()
+                .map_err(|e| AlgoKitTransactError::DecodingError {
+                    error_msg: format!("Error while decoding a logic signature signature: {}", e),
+                })?,
+            multisignature: lsig.multisignature.map(TryInto::try_into).transpose()?,
+            logic_multisignature: lsig
+                .logic_multisignature
+                .map(TryInto::try_into)
+                .transpose()?,
+            args: lsig.args,
+        })
+    }
+}
+
+/// Returns the escrow address a program authorizes as when it is not delegated.
+#[ffi_func]
+pub fn get_logic_signature_address(logic: Vec<u8>) -> Result<String, AlgoKitTransactError> {
+    Ok(algokit_transact::LogicSignature::new(logic)
+        .address()
+        .to_string())
+}
+
+/// Returns the bytes an account signs to delegate a program to itself.
+#[ffi_func]
+pub fn get_logic_signature_bytes_to_sign(logic: Vec<u8>) -> Result<Vec<u8>, AlgoKitTransactError> {
+    Ok(algokit_transact::LogicSignature::new(logic).bytes_to_sign())
+}
+
+/// Returns the bytes a multisig participant signs to delegate a program.
+#[ffi_func]
+pub fn get_logic_signature_bytes_to_sign_for_multisig(
+    logic: Vec<u8>,
+    multisignature: MultisigSignature,
+) -> Result<Vec<u8>, AlgoKitTransactError> {
+    let msig: algokit_transact::MultisigSignature = multisignature.try_into()?;
+    Ok(algokit_transact::LogicSignature::new(logic).bytes_to_sign_for_multisig(&msig))
+}
+
+/// Validates a logic signature, returning the reasons it is not well formed.
+#[ffi_func]
+pub fn validate_logic_signature(
+    logic_signature: LogicSignature,
+) -> Result<(), AlgoKitTransactError> {
+    let lsig: algokit_transact::LogicSignature = logic_signature.try_into()?;
+    lsig.validate()
+        .map_err(|errors| AlgoKitTransactError::DecodingError {
+            error_msg: errors.join("; "),
+        })
+}

--- a/crates/algokit_transact_ffi/src/multisig.rs
+++ b/crates/algokit_transact_ffi/src/multisig.rs
@@ -206,6 +206,7 @@ mod tests {
                 )
                     .unwrap(),
             ),
+            logic_signature: None,
         };
         assert_eq!(
             observed_signed_txn.encode().unwrap(),

--- a/crates/algokit_transact_ffi/src/signer.rs
+++ b/crates/algokit_transact_ffi/src/signer.rs
@@ -56,5 +56,6 @@ pub fn ed25519_sign_transaction(
         auth_address: None,
         signature: Some(signature.into()),
         multisignature: None,
+        logic_signature: None,
     })
 }

--- a/crates/algokit_transact_ffi/src/transactions/app_call.rs
+++ b/crates/algokit_transact_ffi/src/transactions/app_call.rs
@@ -68,6 +68,118 @@ pub struct AppCallTransactionFields {
 
     /// The boxes that should be made available for the runtime of the program.
     box_references: Option<Vec<BoxReference>>,
+
+    /// The unified access list, replacing the separate reference arrays above.
+    access: Option<Vec<ResourceRef>>,
+}
+
+/// A single entry in an app call's access list.
+///
+/// At most one field is set. An entry with none set bumps the box read/write quota.
+#[ffi_record]
+pub struct ResourceRef {
+    /// An account made available to the program.
+    address: Option<String>,
+
+    /// An asset made available to the program.
+    asset: Option<u64>,
+
+    /// An app made available to the program.
+    app: Option<u64>,
+
+    /// An asset holding, naming an account and an asset already in the access list.
+    holding: Option<HoldingRef>,
+
+    /// An account's local state for an app, both already in the access list.
+    locals: Option<LocalsRef>,
+
+    /// A box owned by an app in the access list. `app_id` here is a 1-based index into
+    /// the access list, not an app ID.
+    box_ref: Option<BoxReference>,
+}
+
+/// An asset holding, by position within the access list.
+#[ffi_record]
+pub struct HoldingRef {
+    /// 0 is the sender, otherwise a 1-based index into the access list.
+    address: u64,
+
+    /// A 1-based index into the access list.
+    asset: u64,
+}
+
+/// An account's local state for an app, by position within the access list.
+#[ffi_record]
+pub struct LocalsRef {
+    /// 0 is the sender, otherwise a 1-based index into the access list.
+    address: u64,
+
+    /// 0 is the app being called, otherwise a 1-based index into the access list.
+    app: u64,
+}
+
+impl From<algokit_transact::HoldingRef> for HoldingRef {
+    fn from(r: algokit_transact::HoldingRef) -> Self {
+        Self {
+            address: r.address,
+            asset: r.asset,
+        }
+    }
+}
+
+impl From<HoldingRef> for algokit_transact::HoldingRef {
+    fn from(r: HoldingRef) -> Self {
+        Self {
+            address: r.address,
+            asset: r.asset,
+        }
+    }
+}
+
+impl From<algokit_transact::LocalsRef> for LocalsRef {
+    fn from(r: algokit_transact::LocalsRef) -> Self {
+        Self {
+            address: r.address,
+            app: r.app,
+        }
+    }
+}
+
+impl From<LocalsRef> for algokit_transact::LocalsRef {
+    fn from(r: LocalsRef) -> Self {
+        Self {
+            address: r.address,
+            app: r.app,
+        }
+    }
+}
+
+impl From<algokit_transact::ResourceRef> for ResourceRef {
+    fn from(r: algokit_transact::ResourceRef) -> Self {
+        Self {
+            address: r.address.map(|a| a.as_str()),
+            asset: r.asset,
+            app: r.app,
+            holding: r.holding.map(Into::into),
+            locals: r.locals.map(Into::into),
+            box_ref: r.box_ref.map(Into::into),
+        }
+    }
+}
+
+impl TryFrom<ResourceRef> for algokit_transact::ResourceRef {
+    type Error = AlgoKitTransactError;
+
+    fn try_from(r: ResourceRef) -> Result<Self, Self::Error> {
+        Ok(Self {
+            address: r.address.map(|a| a.parse()).transpose()?,
+            asset: r.asset,
+            app: r.app,
+            holding: r.holding.map(Into::into),
+            locals: r.locals.map(Into::into),
+            box_ref: r.box_ref.map(Into::into),
+        })
+    }
 }
 
 impl From<algokit_transact::AppCallTransactionFields> for AppCallTransactionFields {
@@ -89,6 +201,9 @@ impl From<algokit_transact::AppCallTransactionFields> for AppCallTransactionFiel
             box_references: tx
                 .box_references
                 .map(|boxes| boxes.into_iter().map(Into::into).collect()),
+            access: tx
+                .access
+                .map(|refs| refs.into_iter().map(Into::into).collect()),
         }
     }
 }
@@ -130,6 +245,14 @@ impl TryFrom<Transaction> for algokit_transact::AppCallTransactionFields {
             box_references: data
                 .box_references
                 .map(|boxes| boxes.into_iter().map(Into::into).collect()),
+            access: data
+                .access
+                .map(|refs| {
+                    refs.into_iter()
+                        .map(TryInto::try_into)
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?,
         };
 
         transaction_fields


### PR DESCRIPTION
## v41 catch-up: logic signatures and unified access lists

Brings `algokit_transact` up to consensus v41, which shipped a year ago. Two wire features were missing entirely, so transactions using them lost data on a decode/re-encode round trip.

**Logic signatures.** `SignedTransaction` had no `lsig` field at all. Adds the type with its four delegation slots, the escrow address derivation, and both signing preimages. Delegation targets `lmsig`; v41 rejects the legacy `msig` on a LogicSig because it hashed the bare program under the same domain separator a single-key delegation uses, letting a member's subsignature be replayed as their own. `msig` is kept decode-only so historical transactions still parse.

**Unified access list.** Replaces the separate account, app, asset and box reference arrays with a single `al` list, doubling the combined limit to 16. Entries name at most one resource; an empty entry is valid and bumps the box quota.

**Zero-signature omission.** Not v41, but included because LogicSig multiplies it. An all-zero signature is the absent signature on the wire — go-algorand and the JS SDK both omit it, we were writing 64 zero bytes, inflating size and fee estimates.